### PR TITLE
Added option to embed plotly.js

### DIFF
--- a/src/api.jl
+++ b/src/api.jl
@@ -48,6 +48,10 @@ function savefig2(p::Plot, fn::AbstractString; dpi::Real=96)
 end
 
 # an alternative way to save plots -- no shelling out, but output less pretty
+# js can be one of
+#    :local - reference the javascript from PlotlyJS installation
+#    :remote - reference the javascript from plotly CDN
+#    :embed - embed the javascript in output (add's 1.7MB to size)
 function savefig(p::Plot, fn::AbstractString; js::Symbol=:local
                 #   sz::Tuple{Int,Int}=(8,6),
                 #   dpi::Int=300

--- a/src/api.jl
+++ b/src/api.jl
@@ -48,7 +48,7 @@ function savefig2(p::Plot, fn::AbstractString; dpi::Real=96)
 end
 
 # an alternative way to save plots -- no shelling out, but output less pretty
-function savefig(p::Plot, fn::AbstractString,
+function savefig(p::Plot, fn::AbstractString; js::Symbol=:local
                 #   sz::Tuple{Int,Int}=(8,6),
                 #   dpi::Int=300
                   )
@@ -59,7 +59,7 @@ function savefig(p::Plot, fn::AbstractString,
     # if html we don't need a plot window
     if suf == "html"
         open(fn, "w") do f
-            writemime(f, MIME"text/html"(), p)
+            writemime(f, MIME"text/html"(), p, js)
         end
         return p
     end

--- a/src/api.jl
+++ b/src/api.jl
@@ -49,9 +49,23 @@ end
 
 # an alternative way to save plots -- no shelling out, but output less pretty
 # js can be one of
-#    :local - reference the javascript from PlotlyJS installation
-#    :remote - reference the javascript from plotly CDN
-#    :embed - embed the javascript in output (add's 1.7MB to size)
+
+"""
+`savefig(p::Plot, fn::AbstractString, js::Symbol)`
+
+Options
+=======
+
+- `p::Plot`: Plotly Plot
+- `fn::AbstractString`: Filename with extension (html, pdf, png)
+- `js::Symbol`: 
+
+**Options for `js`**
+
+- `:local` - reference the javascript from PlotlyJS installation
+- `:remote` - reference the javascript from plotly CDN
+- `:embed` - embed the javascript in output (add's 1.7MB to size)
+"""
 function savefig(p::Plot, fn::AbstractString; js::Symbol=:local
                 #   sz::Tuple{Int,Int}=(8,6),
                 #   dpi::Int=300

--- a/src/display.jl
+++ b/src/display.jl
@@ -30,63 +30,33 @@ script_content(p::Plot) = """
 function stringmime(::MIME"text/html", p::Plot, js::Symbol=:local)
 
     if js == :local
-        str = """
-              <html>
-              <head>
-                   <script src="$(_js_path)"></script>
-              </head>
-              <body>
-                   $(html_body(p))
-              </body>
-              </html>
-    """
+        script_txt = "<script src=\"$(_js_path)\"></script>"
     elseif js == :remote
-        str = """
-              <html>
-              <head>
-                   <script src="$(_js_cdn_path)"></script>
-              </head>
-              <body>
-                   $(html_body(p))
-              </body>
-              </html>
-              """           
+        script_txt = "<script src=\"$(_js_cdn_path)\"></script>"
     elseif js == :embed
-        str = """
-              <html>
-              <head>
-                   <script>
-                      $(plotlyjs_str(_js_path))
-                   </script>
-              </head>
-
-              <body>
-                      $(html_body(p))
-              </body>
-              </html>
-              """             
+        script_txt = "<script>$(readall(_js_path))</script>"
     else
-        error("unknon argument $js")
+        msg = """
+        Unknown value for argument js: $js.
+        Possible choices are `:local`, `:remote`, `:embed`
+            """
+        throw(ArgumentError(msg))
     end
     
-    str
+
+    """
+    <html>
+    <head>
+         $script_txt
+    </head>
+    <body>
+         $(html_body(p))
+    </body>
+    </html>
+    """
 
 end
 
-
-#stringmime(::MIME"text/html", p::Plot) =  """
-#    <html>
-#    <head>
-#        <script>
-#           $(plotlyjs_str(_js_path))
-#        </script>
-#    </head>
-
-#    <body>
-#      $(html_body(p))
-#    </body>
-#    </html>
-#    """
 
 Base.writemime(io::IO, ::MIME"text/html", p::Plot, js::Symbol=:local) =
     print(io, stringmime(MIME"text/html"(), p, js))

--- a/src/display.jl
+++ b/src/display.jl
@@ -5,7 +5,6 @@
 const _js_path = joinpath(dirname(dirname(@__FILE__)),
                           "deps", "plotly-latest.min.js")
 const _js_cdn_path = "https://cdn.plot.ly/plotly-latest.min.js"
-plotlyjs_str(fn) = join(readlines(open(fn, "r")))
 
 
 function html_body(p::Plot)


### PR DESCRIPTION
change affects `savefig()` with an optional parameter `js`. If skipped then does not affect the behavior. With `:remote` and `:embed` it would either reference the CDN for javascript or embed it directly inside the html. 