### PR TITLE
fix a warning

### DIFF
--- a/src/api.jl
+++ b/src/api.jl
@@ -143,13 +143,6 @@ function restyle!(p::Plot, inds::AbstractVector{Int},
     map((ind, i) -> restyle!(p.data[ind], i, d), inds, 1:N)
 end
 
-"""
-`restyle!(p::Plot, update::Associative=Dict(); kwargs...)`
-
-Update all traces using update dict and/or kwargs
-"""
-restyle!(p::Plot, update::Associative=Dict(); kwargs...) =
-    restyle!(p, 1:length(p.data), update; kwargs...)
 
 @doc """
 The `restyle!` method follows the semantics of the `Plotly.restyle` function in


### PR DESCRIPTION
```
WARNING: Method definition restyle!(PlotlyJS.Plot) in module PlotlyJS at /home/roger/.julia/v0.5/PlotlyJS/src/api.jl:126 overwritten at /home/roger/.julia/v0.5/PlotlyJS/src/api.jl:151.
```