### PR TITLE
Let string interpolation stringify to JSON format

### DIFF
--- a/src/json.jl
+++ b/src/json.jl
@@ -43,6 +43,9 @@ function JSON._print(io::IO, state::JSON.State, p::Plot)
     JSON.end_object(io, state, true)
 end
 
+# Let string interpolation stringify to JSON format
+Base.print(io::IO, a::Union{Shape,GenericTrace,PlotlyAttribute,Layout,Plot}) = print(io, JSON.json(a))
+
 # methods to re-construct a plot from JSON
 _symbol_dict(x) = x
 _symbol_dict(d::Associative) =


### PR DESCRIPTION
Hi @spencerlyon2 ,

I'd like to be able to use your PlotlyJS types with string interpolation so this PR simply adds a `print` method so that we can do things like:

~~~julia
julia> using PlotlyJS

julia> t1 = scatter(;x=[1, 2, 3, 4, 5],
                     y=[1, 6, 3, 6, 1],
                     mode="markers+text",
                     name="Team A",
                     text=["A-1", "A-2", "A-3", "A-4", "A-5"],
                     textposition="top center",
                     textfont_family="Raleway, sans-serif",
                     marker_size=12)
scatter with fields marker, mode, name, text, textfont, textposition, x, and y

julia> "hello $t1"
"hello {\"type\":\"scatter\",\"y\":[1,6,3,6,1],\"text\":[\"A-1\",\"A-2\",\"A-3\",\"A-4\",\"A-5\"],\"textfont\":{\"family\":\"Raleway, sans-serif\"},\"name\":\"Team A\",\"x\":[1,2,3,4,5],\"textposition\":\"top center\",\"mode\":\"markers+text\",\"marker\":{\"size\":12}}"
~~~ 

What do you think?