### PR TITLE
JSON for vectors of traces.

### DIFF
--- a/src/json.jl
+++ b/src/json.jl
@@ -45,6 +45,7 @@ end
 
 # Let string interpolation stringify to JSON format
 Base.print(io::IO, a::Union{Shape,GenericTrace,PlotlyAttribute,Layout,Plot}) = print(io, JSON.json(a))
+Base.print{T<:GenericTrace}(io::IO, a::Vector{T}) = print(io, JSON.json(a))
 
 # methods to re-construct a plot from JSON
 _symbol_dict(x) = x


### PR DESCRIPTION
My previous PR ( #38 ) allowed for string interpolation of basic PlotlyJS types including GenericTrace. In addition to those, we also need vectors of generic traces. This PR completes that.

I use this in Pages.jl for sending JS commands from Julia to a browser, e.g.

~~~julia
n = 10
trace1 = scatter(;x = 1:n, y = rand(n))
trace2 = scatter(;x = 1:n, y = rand(n))
data = [trace1, trace2]
layout = Layout(;title = "Create a new <div> and plot an array of traces",
    width = 600,
    height = 300
)
id = "Plot2"
add_div(id)
Pages.broadcast("script","""Plotly.newPlot("$(id)",$(data),$(layout));""")
~~~

Without this PR, I'd need to do this instead:

~~~julia
n = 10
trace1 = scatter(;x = 1:n, y = rand(n))
trace2 = scatter(;x = 1:n, y = rand(n))
data = [trace1, trace2]
layout = Layout(;title = "Create a new <div> and plot an array of traces",
    width = 600,
    height = 300
)
id = "Plot2"
add_div(id)
Pages.broadcast("script","""Plotly.newPlot("$(id)",[$(trace1),$(trace2)],$(layout));""") # Note the individual traces.
~~~
