### PR TITLE
Added capability to resize the plot along with the electron display

### DIFF
--- a/src/display.jl
+++ b/src/display.jl
@@ -9,7 +9,7 @@ function html_body(p::Plot)
     <script>
         window.PLOTLYENV=window.PLOTLYENV || {};
         window.PLOTLYENV.BASE_URL="https://plot.ly";
-       $(script_content(p))
+        $(script_content(p))
      </script>
     """
 end

--- a/src/displays/electron.jl
+++ b/src/displays/electron.jl
@@ -46,19 +46,47 @@ end
 function Base.display(p::ElectronPlot)
     w = get_window(p)
     loadjs(p.view)
-    @js w begin
-        trydiv = document.getElementById($(string(p.plot.divid)))
-        if trydiv == nothing
-            thediv = document.createElement("div")
-            thediv.id = $(string(p.plot.divid))
-            document.body.appendChild(thediv)
-        else
-            thediv = trydiv
+    if isdefined(Main, :ELECTRON_FIXED_SIZE_PLOT)&& (Main.ELECTRON_FIXED_SIZE_PLOT)
+        @js w begin
+            trydiv = document.getElementById($(string(p.plot.divid)))
+            if trydiv == nothing
+                thediv = document.createElement("div")
+                thediv.id = $(string(p.plot.divid))
+                document.body.appendChild(thediv)
+            else
+                thediv = trydiv
+            end
+            @var _ = Plotly.newPlot(thediv, $(p.plot.data),
+            $(p.plot.layout),
+            d("showLink"=> false))
+            _.then(()->Promise.resolve())
         end
-        @var _ = Plotly.newPlot(thediv, $(p.plot.data),
-                                $(p.plot.layout),
-                                d("showLink"=> false))
-        _.then(()->Promise.resolve())
+    else
+        magic = """
+        <script>
+        (function() {
+        var d3 = Plotly.d3
+        var WIDTH_IN_PERCENT_OF_PARENT = 100,
+        HEIGHT_IN_PERCENT_OF_PARENT = 100;
+        var gd3 = d3.select('body')
+        .append('div')
+        .style({
+        width: WIDTH_IN_PERCENT_OF_PARENT + '%',
+        'margin-left': (100 - WIDTH_IN_PERCENT_OF_PARENT) / 2 + '%',
+        height: HEIGHT_IN_PERCENT_OF_PARENT + 'vh',
+        'margin-top': (100 - HEIGHT_IN_PERCENT_OF_PARENT) / 2 + 'vh'
+        });
+        var gd = gd3.node();
+        var data = $(json(p.plot.data))
+        var layouts = $(json(p.plot.layout))
+        Plotly.newPlot(gd, data, layouts);
+        window.onresize = function() {
+        Plotly.Plots.resize(gd);
+        };
+        })();
+        </script>
+        """
+        Blink.body!(w, magic)
     end
     p.plot
 end


### PR DESCRIPTION
The default behavior is to resize the plot as the electron window is being resized. To turn it off, the used just needs to define in in Main

ELECTRON_FIXED_SIZE_PLOT= true

