### PR TITLE
Remove `kind` field for GenericTrace and Shape.

### DIFF
--- a/src/api.jl
+++ b/src/api.jl
@@ -24,8 +24,7 @@ for t in [:histogram, :scatter3d, :surface, :mesh3d, :bar, :histogram2d,
     eval(Expr(:export, t))
 end
 
-Base.copy(gt::GenericTrace) = GenericTrace(gt.kind, deepcopy(gt.fields))
-Base.copy(l::Layout) = Layout(deepcopy(l.fields))
+Base.copy{HF<:HasFields}(hf::HF) = HF(deepcopy(hf.fields))
 Base.copy(p::Plot) = Plot([copy(t) for t in p.data], copy(p.layout))
 fork(p::Plot) = Plot(deepcopy(p.data), copy(p.layout), Base.Random.uuid4())
 

--- a/src/json.jl
+++ b/src/json.jl
@@ -1,47 +1,14 @@
 # -------------------------------- #
 # Custom JSON output for our types #
 # -------------------------------- #
-# Shape and GenericTrace have the same fields and json representation
-function JSON._print(io::IO, state::JSON.State, a::Union{Shape,GenericTrace})
-    JSON.start_object(io, state, true)
-    range = keys(a.fields)
-    if length(range) > 0
-        Base.print(io, JSON.prefix(state), "\"", :type, "\"", JSON.separator(state))
-        JSON._print(io, state, a.kind)
-
-        for name in range
-            Base.print(io, ",")
-            JSON.printsp(io, state)
-            Base.print(io, "\"", name, "\"", JSON.separator(state))
-            JSON._print(io, state, a.fields[name])
-        end
-    end
-    JSON.end_object(io, state, true)
-end
-
-JSON._print(io::IO, state::JSON.State, a::Union{PlotlyAttribute,Layout}) =
+JSON._print(io::IO, state::JSON.State, a::HasFields) =
     JSON._print(io, state, a.fields)
-
-JSON._print(io::IO, state::JSON.State, a::Colors.Colorant) =
-    JSON._print(io, state, string("#", hex(a)))
 
 JSON._print(io::IO, state::JSON.State, d::Base.Dates.Date) =
     JSON._print(io, state, "$(year(d))-$(month(d))-$(day(d))")
 
-function JSON._print(io::IO, state::JSON.State, p::Plot)
-    JSON.start_object(io, state, true)
-
-    # print data
-    Base.print(io, JSON.prefix(state), "\"data\"", JSON.separator(state))
-    JSON._print(io, state, p.data)
-    Base.print(io, ",")
-
-    # print layout
-    JSON.printsp(io, state)
-    Base.print(io, JSON.prefix(state), "\"layout\"", JSON.separator(state))
-    JSON._print(io, state, p.layout)
-    JSON.end_object(io, state, true)
-end
+JSON._print(io::IO, state::JSON.State, p::Plot) =
+    JSON._print(io, state, Dict(:data => p.data, :layout => p.layout))
 
 # Let string interpolation stringify to JSON format
 Base.print(io::IO, a::Union{Shape,GenericTrace,PlotlyAttribute,Layout,Plot}) = print(io, JSON.json(a))

--- a/src/traces_layouts.jl
+++ b/src/traces_layouts.jl
@@ -2,13 +2,13 @@ abstract AbstractTrace
 abstract AbstractLayout
 
 type GenericTrace{T<:Associative{Symbol,Any}} <: AbstractTrace
-    kind::String
     fields::T
 end
 
 function GenericTrace(kind::AbstractString, fields=Dict{Symbol,Any}(); kwargs...)
     # use setindex! methods below to handle `_` substitution
-    gt = GenericTrace(kind, fields)
+    fields[:type] = kind
+    gt = GenericTrace(fields)
     map(x->setindex!(gt, x[2], x[1]), kwargs)
     gt
 end
@@ -28,7 +28,7 @@ end
 Layout{T<:Associative{Symbol,Any}}(fields::T=Dict{Symbol,Any}(); kwargs...) =
     Layout{T}(fields; kwargs...)
 
-kind(gt::GenericTrace) = gt.kind
+kind(gt::GenericTrace) = get(gt, :type, "scatter")
 kind(l::Layout) = "layout"
 
 # -------------------------------------------- #
@@ -60,13 +60,13 @@ typealias _Scalar Union{Base.Dates.Date,Number,AbstractString}
 # ------ #
 
 type Shape <: AbstractLayoutAttribute
-    kind::String
     fields::Associative{Symbol}
 end
 
 function Shape(kind::AbstractString, fields=Dict{Symbol,Any}(); kwargs...)
     # use setindex! methods below to handle `_` substitution
-    s = Shape(kind, fields)
+    fields[:type] = kind
+    s = Shape(fields)
     map(x->setindex!(s, x[2], x[1]), kwargs)
     s
 end

--- a/test/traces.jl
+++ b/test/traces.jl
@@ -2,18 +2,18 @@
 gt = M.GenericTrace("scatter"; x=1:10, y=sin(1:10))
 
 @testset "test constructors" begin
-    @test sort(collect(keys(gt.fields))) == [:x, :y]
+    @test sort(collect(keys(gt.fields))) == [:type, :x, :y]
 end
 
 @testset "test setindex!, getindex methods" begin
     gt[:visible] = true
-    @test length(gt.fields) == 3
+    @test length(gt.fields) == 4
     @test haskey(gt.fields, :visible)
     @test gt.fields[:visible] == true
 
     # now try with string. Make sure it updates inplace
     gt["visible"] = false
-    @test length(gt.fields) == 3
+    @test length(gt.fields) == 4
     @test haskey(gt.fields, :visible)
     @test gt.fields[:visible] == false
 
@@ -21,7 +21,7 @@ end
     # 2 levels #
     # -------- #
     gt[:line, :color] = "red"
-    @test length(gt.fields) == 4
+    @test length(gt.fields) == 5
     @test haskey(gt.fields, :line)
     @test isa(gt.fields[:line], Dict)
     @test gt.fields[:line][:color] == "red"
@@ -29,7 +29,7 @@ end
 
     # now try string version
     gt["line", "color"] = "blue"
-    @test length(gt.fields) == 4
+    @test length(gt.fields) == 5
     @test haskey(gt.fields, :line)
     @test isa(gt.fields[:line], Dict)
     @test gt.fields[:line][:color] == "blue"
@@ -37,7 +37,7 @@ end
 
     # now try convenience string dot notation
     gt["line.color"] = "green"
-    @test length(gt.fields) == 4
+    @test length(gt.fields) == 5
     @test haskey(gt.fields, :line)
     @test isa(gt.fields[:line], Dict)
     @test gt.fields[:line][:color] == "green"
@@ -45,7 +45,7 @@ end
 
     # now try symbol with underscore
     gt[:(line_color)] = "orange"
-    @test length(gt.fields) == 4
+    @test length(gt.fields) == 5
     @test haskey(gt.fields, :line)
     @test isa(gt.fields[:line], Dict)
     @test gt.fields[:line][:color] == "orange"
@@ -53,7 +53,7 @@ end
 
     # now try string with underscore
     gt["line_color"] = "magenta"
-    @test length(gt.fields) == 4
+    @test length(gt.fields) == 5
     @test haskey(gt.fields, :line)
     @test isa(gt.fields[:line], Dict)
     @test gt.fields[:line][:color] == "magenta"
@@ -63,7 +63,7 @@ end
     # 3 levels #
     # -------- #
     gt[:marker, :line, :color] = "red"
-    @test length(gt.fields) == 5
+    @test length(gt.fields) == 6
     @test haskey(gt.fields, :marker)
     @test isa(gt.fields[:marker], Dict)
     @test haskey(gt.fields[:marker], :line)
@@ -74,7 +74,7 @@ end
 
     # now try string version
     gt["marker", "line", "color"] = "blue"
-    @test length(gt.fields) == 5
+    @test length(gt.fields) == 6
     @test haskey(gt.fields, :marker)
     @test isa(gt.fields[:marker], Dict)
     @test haskey(gt.fields[:marker], :line)
@@ -85,7 +85,7 @@ end
 
     # now try convenience string dot notation
     gt["marker.line.color"] = "green"
-    @test length(gt.fields) == 5
+    @test length(gt.fields) == 6
     @test haskey(gt.fields, :marker)
     @test isa(gt.fields[:marker], Dict)
     @test haskey(gt.fields[:marker], :line)
@@ -96,7 +96,7 @@ end
 
     # now string with underscore notation
     gt["marker_line_color"] = "orange"
-    @test length(gt.fields) == 5
+    @test length(gt.fields) == 6
     @test haskey(gt.fields, :marker)
     @test isa(gt.fields[:marker], Dict)
     @test haskey(gt.fields[:marker], :line)
@@ -107,7 +107,7 @@ end
 
     # now symbol with underscore notation
     gt[:(marker_line_color)] = "magenta"
-    @test length(gt.fields) == 5
+    @test length(gt.fields) == 6
     @test haskey(gt.fields, :marker)
     @test isa(gt.fields[:marker], Dict)
     @test haskey(gt.fields[:marker], :line)
@@ -120,7 +120,7 @@ end
     # 4 levels #
     # -------- #
     gt[:marker, :colorbar, :tickfont, :family] = "Hasklig-ExtraLight"
-    @test length(gt.fields) == 5  # notice we didn't add another top level key
+    @test length(gt.fields) == 6  # notice we didn't add another top level key
     @test haskey(gt.fields, :marker)
     @test isa(gt.fields[:marker], Dict)
     @test length(gt.fields[:marker]) == 2  # but we did add a key at this level
@@ -134,7 +134,7 @@ end
 
     # now try string version
     gt["marker", "colorbar", "tickfont", "family"] = "Hasklig-Light"
-    @test length(gt.fields) == 5
+    @test length(gt.fields) == 6
     @test haskey(gt.fields, :marker)
     @test isa(gt.fields[:marker], Dict)
     @test length(gt.fields[:marker]) == 2
@@ -148,7 +148,7 @@ end
 
     # now try convenience string dot notation
     gt["marker.colorbar.tickfont.family"] = "Hasklig-Medium"
-    @test length(gt.fields) == 5  # notice we didn't add another top level key
+    @test length(gt.fields) == 6  # notice we didn't add another top level key
     @test haskey(gt.fields, :marker)
     @test isa(gt.fields[:marker], Dict)
     @test length(gt.fields[:marker]) == 2  # but we did add a key at this level
@@ -162,7 +162,7 @@ end
 
     # now string with underscore notation
     gt["marker_colorbar_tickfont_family"] = "Webdings"
-    @test length(gt.fields) == 5  # notice we didn't add another top level key
+    @test length(gt.fields) == 6  # notice we didn't add another top level key
     @test haskey(gt.fields, :marker)
     @test isa(gt.fields[:marker], Dict)
     @test length(gt.fields[:marker]) == 2  # but we did add a key at this level
@@ -176,7 +176,7 @@ end
 
     # now symbol with underscore notation
     gt[:marker_colorbar_tickfont_family] = "Webdings42"
-    @test length(gt.fields) == 5  # notice we didn't add another top level key
+    @test length(gt.fields) == 6  # notice we didn't add another top level key
     @test haskey(gt.fields, :marker)
     @test isa(gt.fields[:marker], Dict)
     @test length(gt.fields[:marker]) == 2  # but we did add a key at this level
@@ -211,7 +211,7 @@ end
     @test vl["x0"] == 0
     @test vl["y0"] == 0
     @test vl["y1"] == 1
-    @test vl.kind == "line"
+    @test vl["type"] == "line"
     @test vl["xref"] == "x"
     @test vl["yref"] == "paper"
 
@@ -219,7 +219,7 @@ end
     @test hl["y0"] == 0
     @test hl["x0"] == 0
     @test hl["x1"] == 1
-    @test hl.kind == "line"
+    @test hl["type"] == "line"
     @test hl["yref"] == "y"
     @test hl["xref"] == "paper"
 
@@ -254,13 +254,13 @@ end
     # constructor logic was taken care of above. Just need to test
     # rect/path/circle specfic things here
     r = rect(1, 2, 3, 4)
-    @test r.kind == "rect"
+    @test r["type"] == "rect"
 
     c = circle(1, 2, 3, 4)
-    @test c.kind == "circle"
+    @test c["type"] == "circle"
 
     _path = "M 1 1 L 1 3 L 4 1 Z"
     p = path(_path)
-    @test p.kind == "path"
+    @test p["type"] == "path"
     @test p["path"] == _path
 end


### PR DESCRIPTION
This makes it so `JSON._print(..., hf::HasFields, ...) = JSON._print(..., hf.fields, ...)`  instead of re-implementing most of the object serialization for `Shape` and `GenericTrace` types. 

Ref: https://github.com/JuliaLang/METADATA.jl/pull/5427

Is there a way to avoid overloading `JSON._print` (hinted at by @TotalVerb [here](https://github.com/JuliaLang/METADATA.jl/pull/5427#issuecomment-226982997))? I don't think defining `JSON.json` will work here for reasons described [here](https://github.com/JuliaLang/METADATA.jl/pull/5427#issuecomment-227211908)

cc @TotalVerb, @tkelman