### PR TITLE
Fixes for Julia 0.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ os:
   - osx
 julia:
   - release
+  - 0.5
   # - nightly
 notifications:
   email: false

--- a/src/PlotlyJS.jl
+++ b/src/PlotlyJS.jl
@@ -1,3 +1,5 @@
+__precompile__()
+
 module PlotlyJS
 
 using Compat; import Compat.String

--- a/src/api.jl
+++ b/src/api.jl
@@ -135,7 +135,7 @@ Update specific traces at `p.data[inds]` using update dict and/or kwargs
 function restyle!(p::Plot, inds::AbstractVector{Int},
                   update::Associative=Dict(); kwargs...)
     N = length(inds)
-    kw = Dict(kwargs)
+    kw = Dict{Symbol,Any}(kwargs)
 
     # prepare update and kw dicts for vectorized application
     for d in (kw, update)

--- a/src/api.jl
+++ b/src/api.jl
@@ -88,8 +88,13 @@ _prep_restyle_vec_setindex(v, N::Int) = v
 
 function _update_fields(hf::GenericTrace, i::Int, update::Dict=Dict(); kwargs...)
     # apply updates in the dict w/out `_` processing
-    map(p -> _apply_restyle_setindex!(hf.fields, p[1], p[2], i), update)
-    map(p -> _apply_restyle_setindex!(hf, p[1], p[2], i), kwargs)
+    for (k,v) in update
+        _apply_restyle_setindex!(hf.fields, k, v, i)
+    end
+    for (k,v) in kwargs
+        _apply_restyle_setindex!(hf, k, v, i)
+    end
+    hf
 end
 
 """
@@ -99,7 +104,10 @@ Update `l` using update dict and/or kwargs
 """
 function relayout!(l::Layout, update::Associative=Dict(); kwargs...)
     merge!(l.fields, update)  # apply updates in the dict w/out `_` processing
-    map(x -> setindex!(l, x[2], x[1]), kwargs)
+    for (k,v) in kwargs
+        setindex!(l, v, k)
+    end
+    l
 end
 
 """

--- a/src/api.jl
+++ b/src/api.jl
@@ -3,7 +3,7 @@
 # -------------------------- #
 
 prep_kwarg(pair::Union{Pair,Tuple}) =
-    (symbol(replace(string(pair[1]), "_", ".")), pair[2])
+    (Symbol(replace(string(pair[1]), "_", ".")), pair[2])
 prep_kwargs(pairs::Union{Associative,Vector}) = Dict(map(prep_kwarg, pairs))
 
 """

--- a/src/json.jl
+++ b/src/json.jl
@@ -20,7 +20,7 @@ Base.print{T<:GenericTrace}(io::IO, a::Vector{T}) = print(io, JSON.json(a))
 # methods to re-construct a plot from JSON
 _symbol_dict(x) = x
 _symbol_dict(d::Associative) =
-    Dict{Symbol,Any}([(symbol(k), _symbol_dict(v)) for (k, v) in d])
+    Dict{Symbol,Any}([(Symbol(k), _symbol_dict(v)) for (k, v) in d])
 
 GenericTrace(d::Associative{Symbol}) = GenericTrace(pop!(d, :type, "scatter"), d)
 GenericTrace{T<:AbstractString}(d::Associative{T}) = GenericTrace(_symbol_dict(d))

--- a/src/traces_layouts.jl
+++ b/src/traces_layouts.jl
@@ -152,10 +152,10 @@ Base.get(hf::HasFields, k::Symbol, default) = get(hf.fields, k, default)
 
 # methods that allow you to do `obj["first.second.third"] = val`
 Base.setindex!(gt::HasFields, val, key::String) =
-    setindex!(gt, val, map(symbol, split(key, ['.', '_']))...)
+    setindex!(gt, val, map(Symbol, split(key, ['.', '_']))...)
 
 Base.setindex!(gt::HasFields, val, keys::String...) =
-    setindex!(gt, val, map(symbol, keys)...)
+    setindex!(gt, val, map(Symbol, keys)...)
 
 # Now for deep setindex. The deepest the json schema ever goes is 4 levels deep
 # so we will simply write out the setindex calls for 4 levels by hand. If the
@@ -199,10 +199,10 @@ end
 # now on to the simpler getindex methods. They will try to get the desired
 # key, but if it doesn't exist an empty dict is returned
 Base.getindex(gt::HasFields, key::String) =
-    getindex(gt, map(symbol, split(key, ['.', '_']))...)
+    getindex(gt, map(Symbol, split(key, ['.', '_']))...)
 
 Base.getindex(gt::HasFields, keys::String...) =
-    getindex(gt, map(symbol, keys)...)
+    getindex(gt, map(Symbol, keys)...)
 
 function Base.getindex(gt::HasFields, key::Symbol)
     if contains(string(key), "_")


### PR DESCRIPTION
This fixes deprecation warnings and errors with Julia 0.5. Getting the tests working was also the occasion for fixing two julia bugs, https://github.com/JuliaLang/julia/pull/17966 and https://github.com/JuliaLang/julia/pull/17968. This won't pass tests on 0.5 until those are backported, but the tests do pass for me locally.