### PR TITLE
Extend `JSON.lower` instead of `JSON.print`

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,5 @@
 julia 0.4
-JSON
+JSON 0.7
 Blink 0.3.3
 Colors
 Compat 0.7.16

--- a/src/json.jl
+++ b/src/json.jl
@@ -1,17 +1,11 @@
 # -------------------------------- #
 # Custom JSON output for our types #
 # -------------------------------- #
-JSON._print(io::IO, state::JSON.State, a::HasFields) =
-    JSON._print(io, state, a.fields)
+JSON.lower(a::HasFields) = a.fields
 
-JSON._print(io::IO, state::JSON.State, d::Base.Dates.Date) =
-    JSON._print(io, state, "$(Base.Dates.year(d))-$(Base.Dates.month(d))-$(Base.Dates.day(d))")
+JSON.lower(p::Plot) = Dict(:data => p.data, :layout => p.layout)
 
-JSON._print(io::IO, state::JSON.State, p::Plot) =
-    JSON._print(io, state, Dict(:data => p.data, :layout => p.layout))
-
-JSON._print(io::IO, state::JSON.State, a::Colors.Colorant) =
-    JSON._print(io, state, string("#", hex(a)))
+JSON.lower(a::Colors.Colorant) = string("#", hex(a))
 
 # Let string interpolation stringify to JSON format
 Base.print(io::IO, a::Union{Shape,GenericTrace,PlotlyAttribute,Layout,Plot}) = print(io, JSON.json(a))


### PR DESCRIPTION
In JSON v0.7.0 and beyond, overloads of _print are deprecated in favour of overloading the simpler lower function.

The new JSON tag is not yet merged; see JuliaLang/METADATA.jl#5988. I'll ping you when it is.