### PR TITLE
Juno Plot Pane Support

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -5,3 +5,4 @@ Colors
 Compat 0.7.16
 LaTeXStrings
 DocStringExtensions
+Juno

--- a/src/PlotlyJS.jl
+++ b/src/PlotlyJS.jl
@@ -86,7 +86,6 @@ export
     init_notebook
 
 function __init__()
-    mediatypes()
     # --------------------------------------------- #
     # Code to run once when the notebook starts up! #
     # --------------------------------------------- #

--- a/src/PlotlyJS.jl
+++ b/src/PlotlyJS.jl
@@ -86,6 +86,7 @@ export
     init_notebook
 
 function __init__()
+    mediatypes()
     # --------------------------------------------- #
     # Code to run once when the notebook starts up! #
     # --------------------------------------------- #

--- a/src/display.jl
+++ b/src/display.jl
@@ -117,6 +117,7 @@ Base.copy(sp::SyncPlot) = fork(sp)  # defined by each SyncPlot{TD}
 # Display frontends #
 # ----------------- #
 
+include("displays/juno.jl")
 include("displays/electron.jl")
 include("displays/ijulia.jl")
 

--- a/src/displays/electron.jl
+++ b/src/displays/electron.jl
@@ -4,13 +4,13 @@
 
 type ElectronDisplay <: AbstractPlotlyDisplay
     divid::Base.Random.UUID
-    w::Nullable{Window}
+    w::Nullable{Any}
     js_loaded::Bool
 end
 
 typealias ElectronPlot SyncPlot{ElectronDisplay}
 
-ElectronDisplay(divid::Base.Random.UUID) = ElectronDisplay(divid, Nullable{Window}(), false)
+ElectronDisplay(divid::Base.Random.UUID) = ElectronDisplay(divid, Nullable(), false)
 ElectronDisplay(p::Plot) = ElectronDisplay(p.divid)
 ElectronPlot(p::Plot) = ElectronPlot(p, ElectronDisplay(p.divid))
 
@@ -29,12 +29,14 @@ function get_window(ed::ElectronDisplay; kwargs...)
     if !isnull(ed.w) && active(get(ed.w))
         w = get(ed.w)
     else
-        w = Window(Blink.AtomShell.shell(), Dict{Any,Any}(kwargs))
-        ed.w = Nullable{Window}(w)
+        w = get_window(Dict(kwargs))
+        ed.w = w
         ed.js_loaded = false  # can't have js if we made a new window
     end
     w
 end
+
+get_window(opts::Dict) = Juno.isactive() ? Juno.Atom.blinkplot() : Window(opts)
 
 js_loaded(ed::ElectronDisplay) = ed.js_loaded
 
@@ -46,7 +48,10 @@ function loadjs(ed::ElectronDisplay)
     end
 end
 
-function Base.display(p::ElectronPlot; show=true, resize::Bool=_autoresize[1])
+Base.display(p::ElectronPlot; show = true, resize::Bool=_autoresize[1]) =
+  display_blink(p; show = show, resize = resize)
+
+function display_blink(p::ElectronPlot; show=true, resize::Bool=_autoresize[1])
     w = get_window(p, show=show)
     loadjs(p.view)
     if !resize

--- a/src/displays/juno.jl
+++ b/src/displays/juno.jl
@@ -1,0 +1,18 @@
+using Juno, Juno.Media, Juno.Hiccup
+
+function mediatypes()
+  media(SyncPlot, Media.Plot)
+end
+
+function Juno.render(::Juno.PlotPane, plot::SyncPlot)
+  display_blink(plot)
+end
+
+@render Juno.Editor p::SyncPlot begin
+  p.plot
+end
+
+@render Juno.Editor p::Plot begin
+  Juno.Tree(span([Juno.Atom.fade("Plotly "), Juno.Atom.icon("graph")]),
+            [p.data, p.layout])
+end

--- a/src/displays/juno.jl
+++ b/src/displays/juno.jl
@@ -1,8 +1,7 @@
-using Juno, Juno.Media, Juno.Hiccup
+using Juno
+import Juno: Tree, Row, icon, fade
 
-function mediatypes()
-  media(SyncPlot, Media.Plot)
-end
+media(SyncPlot, Media.Plot)
 
 function Juno.render(::Juno.PlotPane, plot::SyncPlot)
   display_blink(plot)
@@ -13,6 +12,5 @@ end
 end
 
 @render Juno.Editor p::Plot begin
-  Juno.Tree(span([Juno.Atom.fade("Plotly "), Juno.Atom.icon("graph")]),
-            [p.data, p.layout])
+  Tree(icon("graph"), [p.data, p.layout])
 end


### PR DESCRIPTION
![toolbar](https://cloud.githubusercontent.com/assets/2234614/18210155/178bcfdc-712f-11e6-8e01-bd8ed92529eb.gif)

This is a fairly simple patch in the end – the change in `electron.jl` is just to load the blink object from Atom if it's available and from Blink.jl directly if not. I'm not sure what you're using the options dict for, or if you use `Window`-specific APIs at any point, so that may be worth checking – but at worst it should work exactly the same in the repl.

Then in `juno.jl` I just register `SyncPlot` as a type of plot (so that it gets routed to the plotpane by default) and display it appropriately.

Just for fun I also added a nice in-editor display for the Plot and SyncPlot types. I haven't tried to display traces and layouts differently within the plot, but if you have any ideas then that's easy to do.

This patch does introduce a dependency on Juno.jl – but don't worry, this is just a small set of pure-Julia packages defining the API, unlike Atom.jl which is half of the Julia package ecosystem ;)