### PR TITLE
Use dark theme in Juno

### DIFF
--- a/src/PlotlyJS.jl
+++ b/src/PlotlyJS.jl
@@ -137,6 +137,8 @@ function __init__()
         @eval SyncPlot(p::Plot) = SyncPlot(p, ElectronDisplay(p))
     end
 
+    global const DEFAULT_STYLE = [_default_style()]
+
 end
 
 

--- a/src/displays/juno.jl
+++ b/src/displays/juno.jl
@@ -1,15 +1,16 @@
 using Juno
-import Juno: Tree, Row, icon, fade
+import Juno: Tree, icon
 
 media(SyncPlot, Media.Plot)
+media(Plot, Media.Plot)
 
-function Juno.render(::Juno.PlotPane, plot::SyncPlot)
+function Media.render(::Juno.PlotPane, plot::SyncPlot)
   display_blink(plot)
 end
 
-@render Juno.Editor p::SyncPlot begin
-  p.plot
-end
+@render Juno.PlotPane plot::Plot SyncPlot(plot)
+
+@render Juno.Editor p::SyncPlot p.plot
 
 @render Juno.Editor p::Plot begin
   Tree(icon("graph"), [p.data, p.layout])

--- a/src/displays/juno.jl
+++ b/src/displays/juno.jl
@@ -4,12 +4,7 @@ import Juno: Tree, icon
 media(SyncPlot, Media.Plot)
 media(Plot, Media.Plot)
 
-function Media.render(::Juno.PlotPane, plot::SyncPlot)
-  style = plot.plot.style
-  style == Style() == DEFAULT_STYLE[1] && (plot.plot.style = gadfly_dark_style())
-  display_blink(plot)
-  plot.plot.style = style
-end
+Media.render(::Juno.PlotPane, plot::SyncPlot) = display_blink(plot)
 
 @render Juno.PlotPane plot::Plot SyncPlot(plot)
 

--- a/src/displays/juno.jl
+++ b/src/displays/juno.jl
@@ -5,7 +5,10 @@ media(SyncPlot, Media.Plot)
 media(Plot, Media.Plot)
 
 function Media.render(::Juno.PlotPane, plot::SyncPlot)
+  style = plot.plot.style
+  style == Style() == DEFAULT_STYLE[1] && (plot.plot.style = gadfly_dark_style())
   display_blink(plot)
+  plot.plot.style = style
 end
 
 @render Juno.PlotPane plot::Plot SyncPlot(plot)

--- a/src/styles.jl
+++ b/src/styles.jl
@@ -220,7 +220,8 @@ const STYLES = [:default, :ggplot, :fivethirtyeight, :seaborn, :gadfly_dark,
 function _default_style()
     env = Symbol(get(ENV, "PLOTLYJS_STYLE", ""))
 
-    env in STYLES ? style(env) : Style()
+    env in STYLES ? style(env) :
+    Juno.isactive() ? style(:gadfly_dark) : Style()
 end
 
 const DEFAULT_STYLE = [_default_style()]

--- a/src/styles.jl
+++ b/src/styles.jl
@@ -224,8 +224,6 @@ function _default_style()
     Juno.isactive() ? style(:gadfly_dark) : Style()
 end
 
-const DEFAULT_STYLE = [_default_style()]
-
 reset_style!() = DEFAULT_STYLE[1] = _default_style()
 use_style!(sty::Symbol) = DEFAULT_STYLE[1] = style(sty)
 use_style!(s::Style) = DEFAULT_STYLE[1] = s

--- a/src/styles.jl
+++ b/src/styles.jl
@@ -165,7 +165,7 @@ function gadfly_dark_style()
                     yaxis=axis,
                     font_color=label_color,
                     titlefont_size=14,
-                    margin=attr(l=65, r=65, t=65, b=65))
+                    margin=attr(l=40, r=10, t=10, b=30))
 
 
     Style(color_cycle=color_cycle, layout=layout)


### PR DESCRIPTION
If the user has not overridden the empty default style, we use gadfly_dark in Juno.

Modifying the plot feels unclean to me, so there may be a nicer way to do that – but I don't think it should cause issues if not.