### PR TITLE
Simpler way to fix use with Interact in IJulia on page refresh

### DIFF
--- a/src/PlotlyJS.jl
+++ b/src/PlotlyJS.jl
@@ -121,7 +121,7 @@ function __init__()
         end
 
         # set up the comms we will use to send js messages to be executed
-        global const _ijulia_eval_comm = Comm(:plotlyjs_eval)
+        global const _ijulia_eval_comm = Ref(Comm(:plotlyjs_eval))
         global const _ijulia_return_comms = ObjectIdDict()
 
         @eval begin

--- a/src/displays/ijulia.jl
+++ b/src/displays/ijulia.jl
@@ -10,7 +10,10 @@ end
 
 typealias JupyterPlot SyncPlot{JupyterDisplay}
 
-JupyterDisplay(p::Plot) = JupyterDisplay(p.divid, false, Condition())
+JupyterDisplay(p::Plot) = begin
+    _ijulia_eval_comm[] = Comm(:plotlyjs_eval)
+    JupyterDisplay(p.divid, false, Condition())
+end
 JupyterPlot(p::Plot) = JupyterPlot(p, JupyterDisplay(p))
 
 fork(jp::JupyterPlot) = JupyterPlot(fork(jp.plot))
@@ -72,7 +75,7 @@ end
 # ---------------- #
 
 _call_js(jd::JupyterDisplay, code) =
-    send_comm(_ijulia_eval_comm, Dict("code" => code))
+    send_comm(_ijulia_eval_comm[], Dict("code" => code))
 
 ## API Methods for JupyterDisplay
 _the_div_js(jd::JupyterDisplay) = "document.getElementById('$(jd.divid)')"


### PR DESCRIPTION
See https://github.com/JuliaLang/Interact.jl/issues/115 for more context

Tl;dr: on page refresh the Jupyter front end clears all registered comms, so the `_ijulia_eval_comm` held by PlotlyJS becomes stale. This change ensures a new global Comm is created every time `JupiterDisplay` is called, which stops the old Comm from becoming stale on page refresh.

